### PR TITLE
Return 429 on too many requests

### DIFF
--- a/gateway/src/utils.ts
+++ b/gateway/src/utils.ts
@@ -2,12 +2,14 @@ export function ctHeader(contentType: string) {
   return { 'Content-Type': contentType }
 }
 
-export function textResponse(status: number, message: string) {
-  return new Response(message, { status, headers: ctHeader('text/plain') })
+export function textResponse(status: number, message: string, headers?: Record<string, string>) {
+  return new Response(message, { status, headers: { ...ctHeader('text/plain'), ...headers } })
 }
 
-export function jsonResponse(data: unknown) {
-  return new Response(JSON.stringify(data, null, 2) + '\n', { headers: ctHeader('application/json') })
+export function jsonResponse(data: unknown, headers?: Record<string, string>) {
+  return new Response(JSON.stringify(data, null, 2) + '\n', {
+    headers: { ...ctHeader('application/json'), ...headers },
+  })
 }
 
 export function response405(...allowMethods: string[]): Response {
@@ -31,14 +33,16 @@ export function getIP(request: Request): string {
 export class ResponseError extends Error {
   status: number
   message: string
+  headers?: Record<string, string>
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, headers?: Record<string, string>) {
     super(message)
     this.status = status
     this.message = message
+    this.headers = headers
   }
 
   response(): Response {
-    return textResponse(this.status, this.message)
+    return textResponse(this.status, this.message, this.headers)
   }
 }


### PR DESCRIPTION
I'm not sure if this is the right solution. I did spend some time trying to understand why my key was deactivated, and I think we need to make the user understand what was the reason.

The `Retry-After` header is an enhancement (which PydanticAI supports).