### PR TITLE
better limit logic

### DIFF
--- a/gateway/limits-schema.sql
+++ b/gateway/limits-schema.sql
@@ -9,6 +9,6 @@ CREATE INDEX IF NOT EXISTS idxSpendCreatedAt ON spend (createdAt DESC);
 CREATE TABLE IF NOT EXISTS keyStatus (
   id TEXT NOT NULL PRIMARY KEY,
   status TEXT NOT NULL,
-  expiresAt TIMESTAMP NOT NULL
+  expiresAt TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idxKeyStatusExpiresAt ON keyStatus (expiresAt DESC);

--- a/gateway/src/gateway.ts
+++ b/gateway/src/gateway.ts
@@ -107,7 +107,7 @@ export async function disableApiKey(
 ): Promise<void> {
   apiKey.status = newStatus
   await disableApiKeyAuth(apiKey, env, expirationTtl)
-  await env.keysDb.disableKey(apiKey.id, reason, newStatus)
+  await env.keysDb.disableKey(apiKey.id, reason, newStatus, expirationTtl)
 }
 
 async function recordSpend(apiKey: ApiKeyInfo, spend: number, env: GatewayEnv): Promise<void> {

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -1,5 +1,12 @@
 export type SubFetch = (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
+export type KeyStatus =
+  | 'active' // when the key is active
+  | 'expired' // when the key expires
+  | 'limit-exceeded' // when the key exceeds the limits
+  | 'disabled' // when the user sets in the UI
+  | 'blocked' // when we got a valid response that we couldn't calculate the cost for
+
 // Info about an API key for a particular provider returned by the DB during a request
 export interface ApiKeyInfo {
   id: string
@@ -7,12 +14,7 @@ export interface ApiKeyInfo {
   team: string
   org: string
   key: string
-  status:
-    | 'active' // when the key is active
-    | 'expired' // when the key expires
-    | 'limit-exceeded' // when the key exceeds the limits
-    | 'disabled' // when the user sets in the UI
-    | 'blocked' // when we got a valid response that we couldn't calculate the cost for
+  status: KeyStatus
   // limits are both optional and nullable to allow for databases that return null
   // limits per apiKey - note the extra field since keys can have a total limit
   keySpendingLimitDaily?: number | null

--- a/gateway/test/index.spec.ts.snap
+++ b/gateway/test/index.spec.ts.snap
@@ -150,7 +150,7 @@ exports[`blocked key > should block if limit is exceeded > kv-value 1`] = `
 {
   "id": "tiny-limit-id",
   "key": "tiny-limit",
-  "keySpendingLimitWeekly": 0.01,
+  "keySpendingLimitDaily": 0.01,
   "org": "org1",
   "otelSettings": null,
   "providers": [
@@ -163,6 +163,7 @@ exports[`blocked key > should block if limit is exceeded > kv-value 1`] = `
   ],
   "status": "limit-exceeded",
   "team": "team1",
+  "teamSpendingLimitMonthly": 4,
   "user": null,
 }
 `;
@@ -202,6 +203,28 @@ exports[`groq > should call groq via gateway > llm 1`] = `
   "x_groq": {
     "id": "req_01k4w2jqx2f31tmse2nw28za8v",
   },
+}
+`;
+
+exports[`key status > should change key status if limit is exceeded > kv-value 1`] = `
+{
+  "id": "tiny-limit-id",
+  "key": "tiny-limit",
+  "keySpendingLimitDaily": 0.01,
+  "org": "org1",
+  "otelSettings": null,
+  "providers": [
+    {
+      "baseUrl": "http://test.example.com/test",
+      "credentials": "test",
+      "injectCost": true,
+      "providerID": "test",
+    },
+  ],
+  "status": "limit-exceeded",
+  "team": "team1",
+  "teamSpendingLimitMonthly": 4,
+  "user": null,
 }
 `;
 


### PR DESCRIPTION
previously if any limit was exceeded the entire query failed so other scopes' spend was not increased. Also the previous solution required two queries while this only requires one. And also avoids the database error which might have been slow.