### PR TITLE
Allow use of Logfire staging write token

### DIFF
--- a/gateway/src/otel/index.ts
+++ b/gateway/src/otel/index.ts
@@ -316,6 +316,9 @@ function getBaseUrl({ baseUrl, writeToken }: OtelSettings): string | undefined {
   if (baseUrl) {
     return baseUrl
   }
-  const regionMatch = /pylf_v\d_(us|eu)/.exec(writeToken)
+  const regionMatch = /pylf_v\d_(us|eu|stagingeu)/.exec(writeToken)
+  if (regionMatch?.[1] === 'stagingeu') {
+    return 'https://logfire-eu.pydantic.info'
+  }
   return regionMatch?.[1] === 'eu' ? 'https://api-eu.logfire.dev' : 'https://api.logfire.dev'
 }


### PR DESCRIPTION
I know there is a problem regarding the domain being outside the `pydantic.dev`, but I want to see what it is.