### PR TITLE
Only block keys temporarily

### DIFF
--- a/gateway/src/gateway.ts
+++ b/gateway/src/gateway.ts
@@ -204,7 +204,8 @@ export async function gatewayWithLimiter(
 }
 
 async function blockApiKey(apiKey: ApiKeyInfo, options: GatewayOptions, reason: string): Promise<void> {
-  await disableApiKey(apiKey, options, reason, 'blocked')
+  const expirationTtl = 300 // block for 5 minutes
+  await disableApiKey(apiKey, options, reason, 'blocked', expirationTtl)
 }
 
 export async function disableApiKey(


### PR DESCRIPTION
Make it so we only block keys for 5 minutes when there is a price calculation failure, rather than permanently.