### PR TITLE
Silence console debug calls in test mode

### DIFF
--- a/gateway/test/setup.ts
+++ b/gateway/test/setup.ts
@@ -1,6 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from 'cloudflare:test'
 import { gatewayFetch } from '@pydantic/ai-gateway'
-import { test as baseTest, beforeAll, beforeEach, expect } from 'vitest'
+import { test as baseTest, beforeAll, beforeEach, expect, vi } from 'vitest'
 import SQL from '../limits-schema.sql?raw'
 import { buildGatewayEnv, type DisableEvent } from './worker'
 
@@ -9,6 +9,8 @@ declare module 'vitest' {
     gateway: TestGateway
   }
 }
+
+vi.mock('../src/refreshGenaiPrices', () => ({ refreshGenaiPrices: vi.fn(() => Promise.resolve()) }))
 
 beforeAll(async () => {
   try {


### PR DESCRIPTION
It's still a good idea to have those console messages in the cloudflare worker logs.